### PR TITLE
Normalize review schema

### DIFF
--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,8 +1,8 @@
 import 'dotenv/config';
 
 export default {
-  schema: './lib/schema.ts',
-  out: './drizzle',
+  schema: './src/lib/schema.ts',
+  out: './src/drizzle',
   url: process.env.DATABASE_URL!,
   dialect: 'postgresql',
 } as const;

--- a/src/drizzle/0001_silky_iceman.sql
+++ b/src/drizzle/0001_silky_iceman.sql
@@ -1,0 +1,67 @@
+CREATE TYPE "public"."pro_con" AS ENUM('pro', 'con');--> statement-breakpoint
+CREATE TABLE "game_images" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"game_id" uuid NOT NULL,
+	"url" text NOT NULL,
+	"caption" text,
+	"sort_order" integer
+);
+--> statement-breakpoint
+CREATE TABLE "game_platforms" (
+	"game_id" uuid NOT NULL,
+	"platform_id" uuid NOT NULL,
+	CONSTRAINT "game_platforms_game_id_platform_id_pk" PRIMARY KEY("game_id","platform_id")
+);
+--> statement-breakpoint
+CREATE TABLE "platforms" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"name" text NOT NULL,
+	CONSTRAINT "platforms_name_unique" UNIQUE("name")
+);
+--> statement-breakpoint
+CREATE TABLE "review_pros_cons" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"review_id" uuid NOT NULL,
+	"text" text NOT NULL,
+	"type" "pro_con" NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "review_tags" (
+	"review_id" uuid NOT NULL,
+	"tag_id" uuid NOT NULL,
+	CONSTRAINT "review_tags_review_id_tag_id_pk" PRIMARY KEY("review_id","tag_id")
+);
+--> statement-breakpoint
+CREATE TABLE "tags" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"name" text NOT NULL,
+	CONSTRAINT "tags_name_unique" UNIQUE("name")
+);
+--> statement-breakpoint
+CREATE TABLE "user_opinions" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"review_id" uuid NOT NULL,
+	"opinion_text" text NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "reviews" DROP CONSTRAINT "reviews_game_id_unique";--> statement-breakpoint
+ALTER TABLE "reviews" ALTER COLUMN "game_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "reviews" ALTER COLUMN "score" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "games" ADD COLUMN "updated_at" timestamp with time zone DEFAULT now();--> statement-breakpoint
+ALTER TABLE "reviews" ADD COLUMN "title" text NOT NULL;--> statement-breakpoint
+ALTER TABLE "reviews" ADD COLUMN "description" text NOT NULL;--> statement-breakpoint
+ALTER TABLE "reviews" ADD COLUMN "introduction" text NOT NULL;--> statement-breakpoint
+ALTER TABLE "reviews" ADD COLUMN "gameplay_features" text NOT NULL;--> statement-breakpoint
+ALTER TABLE "reviews" ADD COLUMN "conclusion" text NOT NULL;--> statement-breakpoint
+ALTER TABLE "reviews" ADD COLUMN "created_at" timestamp with time zone DEFAULT now();--> statement-breakpoint
+ALTER TABLE "reviews" ADD COLUMN "updated_at" timestamp with time zone DEFAULT now();--> statement-breakpoint
+ALTER TABLE "game_images" ADD CONSTRAINT "game_images_game_id_games_id_fk" FOREIGN KEY ("game_id") REFERENCES "public"."games"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "game_platforms" ADD CONSTRAINT "game_platforms_game_id_games_id_fk" FOREIGN KEY ("game_id") REFERENCES "public"."games"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "game_platforms" ADD CONSTRAINT "game_platforms_platform_id_platforms_id_fk" FOREIGN KEY ("platform_id") REFERENCES "public"."platforms"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "review_pros_cons" ADD CONSTRAINT "review_pros_cons_review_id_reviews_id_fk" FOREIGN KEY ("review_id") REFERENCES "public"."reviews"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "review_tags" ADD CONSTRAINT "review_tags_review_id_reviews_id_fk" FOREIGN KEY ("review_id") REFERENCES "public"."reviews"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "review_tags" ADD CONSTRAINT "review_tags_tag_id_tags_id_fk" FOREIGN KEY ("tag_id") REFERENCES "public"."tags"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "user_opinions" ADD CONSTRAINT "user_opinions_review_id_reviews_id_fk" FOREIGN KEY ("review_id") REFERENCES "public"."reviews"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "reviews" DROP COLUMN "pros";--> statement-breakpoint
+ALTER TABLE "reviews" DROP COLUMN "cons";--> statement-breakpoint
+ALTER TABLE "reviews" DROP COLUMN "body_markdown";

--- a/src/drizzle/meta/0001_snapshot.json
+++ b/src/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,567 @@
+{
+  "id": "05190a2a-d0dd-4a48-8b5b-b25a7b538996",
+  "prevId": "9cdd97f2-70e3-4e6a-85c8-9a1dde5ecd56",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.game_images": {
+      "name": "game_images",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "caption": {
+          "name": "caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "game_images_game_id_games_id_fk": {
+          "name": "game_images_game_id_games_id_fk",
+          "tableFrom": "game_images",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_platforms": {
+      "name": "game_platforms",
+      "schema": "",
+      "columns": {
+        "game_id": {
+          "name": "game_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "game_platforms_game_id_games_id_fk": {
+          "name": "game_platforms_game_id_games_id_fk",
+          "tableFrom": "game_platforms",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "game_platforms_platform_id_platforms_id_fk": {
+          "name": "game_platforms_platform_id_platforms_id_fk",
+          "tableFrom": "game_platforms",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "game_platforms_game_id_platform_id_pk": {
+          "name": "game_platforms_game_id_platform_id_pk",
+          "columns": [
+            "game_id",
+            "platform_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.games": {
+      "name": "games",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_date": {
+          "name": "release_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hero_url": {
+          "name": "hero_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trailer_url": {
+          "name": "trailer_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "developer": {
+          "name": "developer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publisher": {
+          "name": "publisher",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "games_slug_unique": {
+          "name": "games_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.platforms": {
+      "name": "platforms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "platforms_name_unique": {
+          "name": "platforms_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.review_pros_cons": {
+      "name": "review_pros_cons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "review_id": {
+          "name": "review_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "pro_con",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "review_pros_cons_review_id_reviews_id_fk": {
+          "name": "review_pros_cons_review_id_reviews_id_fk",
+          "tableFrom": "review_pros_cons",
+          "tableTo": "reviews",
+          "columnsFrom": [
+            "review_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.review_tags": {
+      "name": "review_tags",
+      "schema": "",
+      "columns": {
+        "review_id": {
+          "name": "review_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "review_tags_review_id_reviews_id_fk": {
+          "name": "review_tags_review_id_reviews_id_fk",
+          "tableFrom": "review_tags",
+          "tableTo": "reviews",
+          "columnsFrom": [
+            "review_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "review_tags_tag_id_tags_id_fk": {
+          "name": "review_tags_tag_id_tags_id_fk",
+          "tableFrom": "review_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "review_tags_review_id_tag_id_pk": {
+          "name": "review_tags_review_id_tag_id_pk",
+          "columns": [
+            "review_id",
+            "tag_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reviews": {
+      "name": "reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "introduction": {
+          "name": "introduction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gameplay_features": {
+          "name": "gameplay_features",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conclusion": {
+          "name": "conclusion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "numeric(3, 1)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "is_published": {
+          "name": "is_published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reviews_game_id_games_id_fk": {
+          "name": "reviews_game_id_games_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_opinions": {
+      "name": "user_opinions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "review_id": {
+          "name": "review_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opinion_text": {
+          "name": "opinion_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_opinions_review_id_reviews_id_fk": {
+          "name": "user_opinions_review_id_reviews_id_fk",
+          "tableFrom": "user_opinions",
+          "tableTo": "reviews",
+          "columnsFrom": [
+            "review_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.pro_con": {
+      "name": "pro_con",
+      "schema": "public",
+      "values": [
+        "pro",
+        "con"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/drizzle/meta/_journal.json
+++ b/src/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1756041923244,
       "tag": "0000_cloudy_tenebrous",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1756121197613,
+      "tag": "0001_silky_iceman",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -18,7 +18,11 @@ export async function getGameBySlug(slug: string) {
   const rows = await db.select({
     id: games.id, slug: games.slug, title: games.title,
     summary: games.summary, heroUrl: games.heroUrl,
-    bodyMd: reviews.bodyMd, score: reviews.score
+    description: reviews.description,
+    introduction: reviews.introduction,
+    gameplayFeatures: reviews.gameplayFeatures,
+    conclusion: reviews.conclusion,
+    score: reviews.score
   })
   .from(games)
   .leftJoin(reviews, eq(reviews.gameId, games.id))

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -1,27 +1,97 @@
-import { pgTable, uuid, text, timestamp, numeric, boolean } from 'drizzle-orm/pg-core';
+import {
+  pgTable,
+  uuid,
+  text,
+  timestamp,
+  numeric,
+  boolean,
+  primaryKey,
+  pgEnum,
+  integer,
+} from 'drizzle-orm/pg-core';
 
 export const games = pgTable('games', {
-	id: uuid('id').defaultRandom().primaryKey(),
-	createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
-	slug: text('slug').notNull().unique(),
-	title: text('title').notNull(),
-	summary: text('summary'),
-	releaseDate: timestamp('release_date', { withTimezone: true }),
-	heroUrl: text('hero_url'),
-	trailerUrl: text('trailer_url'),
-	developer: text('developer'),
-	publisher: text('publisher'),
+  id: uuid('id').defaultRandom().primaryKey(),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow(),
+  slug: text('slug').notNull().unique(),
+  title: text('title').notNull(),
+  summary: text('summary'),
+  releaseDate: timestamp('release_date', { withTimezone: true }),
+  heroUrl: text('hero_url'),
+  trailerUrl: text('trailer_url'),
+  developer: text('developer'),
+  publisher: text('publisher'),
+});
+
+export const platforms = pgTable('platforms', {
+  id: uuid('id').defaultRandom().primaryKey(),
+  name: text('name').notNull().unique(),
+});
+
+export const gamePlatforms = pgTable(
+  'game_platforms',
+  {
+    gameId: uuid('game_id').references(() => games.id).notNull(),
+    platformId: uuid('platform_id').references(() => platforms.id).notNull(),
+  },
+  (t) => ({
+    pk: primaryKey({ columns: [t.gameId, t.platformId] }),
+  }),
+);
+
+export const gameImages = pgTable('game_images', {
+  id: uuid('id').defaultRandom().primaryKey(),
+  gameId: uuid('game_id').references(() => games.id).notNull(),
+  url: text('url').notNull(),
+  caption: text('caption'),
+  sortOrder: integer('sort_order'),
 });
 
 export const reviews = pgTable('reviews', {
-	id: uuid('id').defaultRandom().primaryKey(),
-	gameId: uuid('game_id').references(() => games.id).unique(),
-	score: numeric('score', { precision: 3, scale: 1 }),
-	pros: text('pros').array(),
-	cons: text('cons').array(),
-	bodyMd: text('body_markdown'),
-	publishedAt: timestamp('published_at', { withTimezone: true }).defaultNow(),
-	isPublished: boolean('is_published').default(true),
+  id: uuid('id').defaultRandom().primaryKey(),
+  gameId: uuid('game_id').references(() => games.id).notNull(),
+  title: text('title').notNull(),
+  description: text('description').notNull(),
+  introduction: text('introduction').notNull(),
+  gameplayFeatures: text('gameplay_features').notNull(),
+  conclusion: text('conclusion').notNull(),
+  score: numeric('score', { precision: 3, scale: 1 }).notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow(),
+  publishedAt: timestamp('published_at', { withTimezone: true }).defaultNow(),
+  isPublished: boolean('is_published').default(true),
+});
+
+export const proConEnum = pgEnum('pro_con', ['pro', 'con']);
+
+export const reviewProsCons = pgTable('review_pros_cons', {
+  id: uuid('id').defaultRandom().primaryKey(),
+  reviewId: uuid('review_id').references(() => reviews.id).notNull(),
+  text: text('text').notNull(),
+  type: proConEnum('type').notNull(),
+});
+
+export const tags = pgTable('tags', {
+  id: uuid('id').defaultRandom().primaryKey(),
+  name: text('name').notNull().unique(),
+});
+
+export const reviewTags = pgTable(
+  'review_tags',
+  {
+    reviewId: uuid('review_id').references(() => reviews.id).notNull(),
+    tagId: uuid('tag_id').references(() => tags.id).notNull(),
+  },
+  (t) => ({
+    pk: primaryKey({ columns: [t.reviewId, t.tagId] }),
+  }),
+);
+
+export const userOpinions = pgTable('user_opinions', {
+  id: uuid('id').defaultRandom().primaryKey(),
+  reviewId: uuid('review_id').references(() => reviews.id).notNull(),
+  opinionText: text('opinion_text').notNull(),
 });
 
 

--- a/src/scripts/seed.ts
+++ b/src/scripts/seed.ts
@@ -13,11 +13,18 @@ async function main() {
 
   await db.insert(reviews).values({
     gameId: g.id,
-    score: '9.0',
-    pros: ['Levelvielfalt', 'Soundtrack'],
-    cons: ['Story flach'],
-    bodyMd: 'Ein sehr gutes Jump & Run…',
+    title: 'Super Mario Wonder Review',
+    description: 'Ein sehr gutes Jump & Run…',
+    introduction: 'Willkommen in der Wunderwelt von Mario!',
+    gameplayFeatures: 'Levelvielfalt, Soundtrack',
+    conclusion: 'Story flach, aber Spielspaß hoch',
+    score: '9.0'
   });
+
   console.log('Seed ok');
 }
-main().then(()=>process.exit(0)).catch(e=>{console.error(e);process.exit(1);});
+
+main().then(() => process.exit(0)).catch(e => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- normalize review lists into dedicated tables for pros/cons, tags, and user opinions
- support game platforms and image galleries
- capture full review content and game metadata timestamps

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac049e3e20832bbc6262fd11eff384