### PR TITLE
feat: add game hero and site header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,8 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+
+.venv
+
+supabase/

--- a/src/app/games/[slug]/page.tsx
+++ b/src/app/games/[slug]/page.tsx
@@ -1,5 +1,6 @@
 import { getGameBySlug } from '@/lib/queries';
 import { notFound } from 'next/navigation';
+import GameHero from '@/components/GameHero';
 
 export const revalidate = 86400;      // 1 Tag
 export const dynamicParams = true;    // neue Slugs sofort möglich
@@ -22,11 +23,19 @@ export default async function Page({ params }: { params: Promise<{ slug: string 
   if (!game) return notFound();
 
   return (
-    <article className="mx-auto max-w-3xl p-6 prose">
-      <h1>{game.title}</h1>
-      <p>{game.summary}</p>
-      <p><strong>Score:</strong> {game.score ?? '—'}</p>
-      {/* Markdown-Body könntest du später mit e.g. marked/rehype rendern */}
-    </article>
+    <>
+      <GameHero
+        title={game.title}
+        developer={game.developer}
+        tags={game.tags ?? []}
+        platforms={game.platforms ?? []}
+        score={game.score ? Number(game.score) : null}
+        heroUrl={game.heroUrl ?? undefined}
+      />
+      <article className="mx-auto max-w-3xl p-6 prose">
+        <p>{game.summary}</p>
+        {/* Markdown-Body könntest du später mit e.g. marked/rehype rendern */}
+      </article>
+    </>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import Script from 'next/script';
+import Header from "@/components/Header";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -21,7 +22,7 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="de">
-      <body>
+      <body className={`${geistSans.variable} ${geistMono.variable}`}>
         {process.env.NODE_ENV === 'production' && (
           <Script
             src="https://umami.mountdoom.space/script.js"
@@ -29,6 +30,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             data-website-id="a696f6b4-f857-4add-a5fa-52469d4f203a"
           />
         )}
+        <Header />
         {children}
       </body>
     </html>

--- a/src/components/GameHero.tsx
+++ b/src/components/GameHero.tsx
@@ -1,0 +1,94 @@
+import Image from 'next/image';
+
+interface GameHeroProps {
+  title: string;
+  developer?: string | null;
+  tags?: string[];
+  platforms?: string[];
+  score?: number | null;
+  heroUrl?: string | null;
+}
+
+export default function GameHero({
+  title,
+  developer,
+  tags = [],
+  platforms = [],
+  score,
+  heroUrl,
+}: GameHeroProps) {
+  const starCount = Math.round(score ?? 0);
+  return (
+    <section className="py-8 bg-white md:py-16 dark:bg-gray-900 antialiased">
+      <div className="max-w-screen-xl px-4 mx-auto 2xl:px-0">
+        <div className="lg:grid lg:grid-cols-2 lg:gap-8 xl:gap-16">
+          {heroUrl && (
+            <div className="shrink-0 max-w-md lg:max-w-lg mx-auto">
+              <Image
+                className="w-full h-auto"
+                src={heroUrl}
+                alt=""
+                width={640}
+                height={480}
+              />
+            </div>
+          )}
+
+          <div className="mt-6 sm:mt-8 lg:mt-0">
+            <h1 className="text-xl font-semibold text-gray-900 sm:text-2xl dark:text-white">
+              {title}
+            </h1>
+            {developer && (
+              <p className="mt-1 text-gray-600 dark:text-gray-300">by {developer}</p>
+            )}
+            {tags.length > 0 && (
+              <div className="mt-4 flex flex-wrap gap-2">
+                {tags.map((tag) => (
+                  <span
+                    key={tag}
+                    className="px-3 py-1 text-xs font-medium rounded-full bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-200"
+                  >
+                    {tag}
+                  </span>
+                ))}
+              </div>
+            )}
+            <div className="mt-4 flex items-center gap-2">
+              <div className="flex items-center gap-1">
+                {[0, 1, 2, 3, 4].map((i) => (
+                  <svg
+                    key={i}
+                    className={`w-4 h-4 ${i < starCount ? 'text-yellow-300' : 'text-gray-300 dark:text-gray-600'}`}
+                    aria-hidden="true"
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="24"
+                    height="24"
+                    fill="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path d="M13.849 4.22c-.684-1.626-3.014-1.626-3.698 0L8.397 8.387l-4.552.361c-1.775.14-2.495 2.331-1.142 3.477l3.468 2.937-1.06 4.392c-.413 1.713 1.472 3.067 2.992 2.149L12 19.35l3.897 2.354c1.52.918 3.405-.436 2.992-2.15l-1.06-4.39 3.468-2.938c1.353-1.146.633-3.336-1.142-3.477l-4.552-.36-1.754-4.17Z" />
+                  </svg>
+                ))}
+              </div>
+              <p className="text-sm font-medium leading-none text-gray-500 dark:text-gray-400">
+                {(score ?? 0).toFixed(1)}
+              </p>
+            </div>
+            {platforms.length > 0 && (
+              <div className="mt-4 flex flex-wrap gap-2">
+                {platforms.map((platform) => (
+                  <span
+                    key={platform}
+                    className="px-3 py-1 text-xs font-medium rounded-full bg-gray-200 text-gray-800 dark:bg-gray-800 dark:text-gray-200"
+                  >
+                    {platform}
+                  </span>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,13 @@
+import Link from 'next/link';
+
+export default function Header() {
+  return (
+    <header className="bg-white dark:bg-gray-900 shadow">
+      <div className="max-w-screen-xl mx-auto px-4 py-4 flex items-center justify-center">
+        <Link href="/" className="text-2xl font-bold text-gray-900 dark:text-white">
+          BestOfGames
+        </Link>
+      </div>
+    </header>
+  );
+}

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -1,5 +1,12 @@
 import { db } from './db';
-import { games, reviews } from './schema';
+import {
+  games,
+  reviews,
+  reviewTags,
+  tags,
+  gamePlatforms,
+  platforms,
+} from './schema';
 import { desc, eq } from 'drizzle-orm';
 
 export async function getRecentReviews(limit = 8) {
@@ -15,19 +22,46 @@ export async function getRecentReviews(limit = 8) {
 }
 
 export async function getGameBySlug(slug: string) {
-  const rows = await db.select({
-    id: games.id, slug: games.slug, title: games.title,
-    summary: games.summary, heroUrl: games.heroUrl,
-    description: reviews.description,
-    introduction: reviews.introduction,
-    gameplayFeatures: reviews.gameplayFeatures,
-    conclusion: reviews.conclusion,
-    score: reviews.score
-  })
-  .from(games)
-  .leftJoin(reviews, eq(reviews.gameId, games.id))
-  .where(eq(games.slug, slug))
-  .limit(1);
+  const rows = await db
+    .select({
+      id: games.id,
+      slug: games.slug,
+      title: games.title,
+      summary: games.summary,
+      heroUrl: games.heroUrl,
+      description: reviews.description,
+      introduction: reviews.introduction,
+      gameplayFeatures: reviews.gameplayFeatures,
+      conclusion: reviews.conclusion,
+      score: reviews.score,
+      developer: games.developer,
+      tagName: tags.name,
+      platformName: platforms.name,
+    })
+    .from(games)
+    .leftJoin(reviews, eq(reviews.gameId, games.id))
+    .leftJoin(reviewTags, eq(reviewTags.reviewId, reviews.id))
+    .leftJoin(tags, eq(reviewTags.tagId, tags.id))
+    .leftJoin(gamePlatforms, eq(gamePlatforms.gameId, games.id))
+    .leftJoin(platforms, eq(gamePlatforms.platformId, platforms.id))
+    .where(eq(games.slug, slug));
 
-  return rows[0] ?? null;
+  if (rows.length === 0) return null;
+
+  const base = rows[0];
+  return {
+    id: base.id,
+    slug: base.slug,
+    title: base.title,
+    summary: base.summary,
+    heroUrl: base.heroUrl,
+    description: base.description,
+    introduction: base.introduction,
+    gameplayFeatures: base.gameplayFeatures,
+    conclusion: base.conclusion,
+    score: base.score,
+    developer: base.developer,
+    tags: Array.from(new Set(rows.map((r) => r.tagName).filter(Boolean))),
+    platforms: Array.from(new Set(rows.map((r) => r.platformName).filter(Boolean))),
+  };
 }

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -61,7 +61,19 @@ export async function getGameBySlug(slug: string) {
     conclusion: base.conclusion,
     score: base.score,
     developer: base.developer,
-    tags: Array.from(new Set(rows.map((r) => r.tagName).filter(Boolean))),
-    platforms: Array.from(new Set(rows.map((r) => r.platformName).filter(Boolean))),
+    tags: Array.from(
+      new Set(
+        rows
+          .map((r) => r.tagName)
+          .filter((name): name is string => typeof name === 'string')
+      )
+    ),
+    platforms: Array.from(
+      new Set(
+        rows
+          .map((r) => r.platformName)
+          .filter((name): name is string => typeof name === 'string')
+      )
+    ),
   };
 }


### PR DESCRIPTION
## Summary
- add reusable GameHero component with developer, tags, platforms and rating
- show GameHero on game detail page and extend query for related data
- introduce simple site header with placeholder logo

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac4b67932c832b96c103d13ddca23f