### PR TITLE
feat: build responsive game details page components

### DIFF
--- a/src/app/games/[slug]/page.tsx
+++ b/src/app/games/[slug]/page.tsx
@@ -1,6 +1,11 @@
 import { getGameBySlug } from '@/lib/queries';
 import { notFound } from 'next/navigation';
-import GameHero from '@/components/GameHero';
+import Hero from '@/components/Hero';
+import ArticleBody, { ArticleBlock } from '@/components/ArticleBody';
+import Section from '@/components/Section';
+import ProsCons from '@/components/ProsCons';
+import StatPill from '@/components/StatPill';
+import CircularScore from '@/components/CircularScore';
 
 export const revalidate = 86400;      // 1 Tag
 export const dynamicParams = true;    // neue Slugs sofort möglich
@@ -21,21 +26,68 @@ export default async function Page({ params }: { params: Promise<{ slug: string 
   const { slug } = await params;
   const game = await getGameBySlug(slug);
   if (!game) return notFound();
+  const images = [game.heroUrl].filter((u): u is string => typeof u === 'string');
+  const paragraphs = [
+    game.introduction,
+    game.description,
+    game.gameplayFeatures,
+    game.conclusion,
+  ].filter((p): p is string => typeof p === 'string');
+  const blocks: ArticleBlock[] = [];
+  paragraphs.forEach((p, i) => {
+    blocks.push({ type: 'paragraph', content: p });
+    if (i % 2 === 1 && game.heroUrl) {
+      blocks.push({ type: 'image', content: game.heroUrl, caption: game.title });
+    }
+  });
+  if (blocks.length === 0 && game.summary) {
+    blocks.push({ type: 'paragraph', content: game.summary });
+  }
 
   return (
     <>
-      <GameHero
+      <Hero
         title={game.title}
-        developer={game.developer}
+        subtitle={game.developer ?? undefined}
         tags={game.tags ?? []}
-        platforms={game.platforms ?? []}
+        images={images}
         score={game.score ? Number(game.score) : null}
-        heroUrl={game.heroUrl ?? undefined}
       />
-      <article className="mx-auto max-w-3xl p-6 prose">
-        <p>{game.summary}</p>
-        {/* Markdown-Body könntest du später mit e.g. marked/rehype rendern */}
-      </article>
+      <main className="mx-auto max-w-3xl p-6">
+        <Section title="About">
+          <ArticleBody blocks={blocks} />
+        </Section>
+        <Section title="Pros & Cons">
+          <ProsCons pros={[]} cons={[]} />
+        </Section>
+        <Section title="User Reviews">
+          <p className="text-text-muted">Community reviews coming soon.</p>
+          <div className="mt-4 flex flex-wrap gap-2">
+            {typeof game.score === 'number' && (
+              <StatPill
+                icon={
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 24 24"
+                    fill="currentColor"
+                    className="h-4 w-4"
+                  >
+                    <path d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z" />
+                  </svg>
+                }
+                label={`${Number(game.score).toFixed(1)} avg`}
+              />
+            )}
+          </div>
+        </Section>
+        {typeof game.score === 'number' && (
+          <Section title="Score">
+            <div className="flex justify-center">
+              <CircularScore value={Number(game.score)} />
+            </div>
+          </Section>
+        )}
+      </main>
     </>
   );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,26 +1,37 @@
 @import "tailwindcss";
 
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
+  --bg: #0b0f17;
+  --surface: #121826;
+  --muted: #9aa4b2;
+  --text: #e6e8ee;
+  --text-muted: #b5bdc9;
+  --accent: #5b8cff;
+  --good: #22c55e;
+  --bad: #ef4444;
+
+  /* legacy aliases */
+  --background: var(--bg);
+  --foreground: var(--text);
 }
 
 @theme inline {
+  --color-bg: var(--bg);
+  --color-surface: var(--surface);
+  --color-muted: var(--muted);
+  --color-text: var(--text);
+  --color-text-muted: var(--text-muted);
+  --color-accent: var(--accent);
+  --color-good: var(--good);
+  --color-bad: var(--bad);
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
-}
-
 body {
-  background: var(--background);
-  color: var(--foreground);
+  background: var(--bg);
+  color: var(--text);
   font-family: Arial, Helvetica, sans-serif;
 }

--- a/src/components/ArticleBody.tsx
+++ b/src/components/ArticleBody.tsx
@@ -1,0 +1,50 @@
+import Image from 'next/image';
+import FadeIn from './FadeIn';
+
+interface ParagraphBlock {
+  type: 'paragraph';
+  content: string;
+}
+
+interface ImageBlock {
+  type: 'image';
+  content: string; // image url
+  caption?: string;
+}
+
+export type ArticleBlock = ParagraphBlock | ImageBlock;
+
+export default function ArticleBody({ blocks }: { blocks: ArticleBlock[] }) {
+  return (
+    <div className="prose prose-invert max-w-none">
+      {blocks.map((block, i) => {
+        if (block.type === 'paragraph') {
+          return (
+            <FadeIn key={i}>
+              <p>{block.content}</p>
+            </FadeIn>
+          );
+        }
+        return (
+          <FadeIn key={i}>
+            <figure className="my-8 overflow-hidden rounded-md transition-transform duration-300 ease-out hover:scale-[1.02] motion-reduce:transition-none">
+              <Image
+                src={block.content}
+                alt={block.caption ?? ''}
+                width={800}
+                height={450}
+                loading="lazy"
+                className="w-full object-cover"
+              />
+              {block.caption && (
+                <figcaption className="mt-2 text-center text-sm text-text-muted">
+                  {block.caption}
+                </figcaption>
+              )}
+            </figure>
+          </FadeIn>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -1,0 +1,26 @@
+import { ReactNode } from 'react';
+
+interface CardProps {
+  children: ReactNode;
+  accent?: 'accent' | 'good' | 'bad';
+  className?: string;
+}
+
+export default function Card({ children, accent, className = '' }: CardProps) {
+  const accentClass =
+    accent === 'good'
+      ? 'border-good'
+      : accent === 'bad'
+      ? 'border-bad'
+      : accent === 'accent'
+      ? 'border-accent'
+      : 'border-surface';
+
+  return (
+    <div
+      className={`rounded-lg border ${accentClass} bg-surface p-6 shadow transition-transform duration-300 ease-out hover:scale-[1.02] hover:shadow-lg motion-reduce:transition-none ${className}`}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/components/CircularScore.tsx
+++ b/src/components/CircularScore.tsx
@@ -1,0 +1,52 @@
+'use client';
+import { useEffect, useState } from 'react';
+
+interface CircularScoreProps {
+  value: number;
+  size?: number;
+}
+
+export default function CircularScore({ value, size = 120 }: CircularScoreProps) {
+  const stroke = 8;
+  const radius = (size - stroke) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const [offset, setOffset] = useState(circumference);
+
+  useEffect(() => {
+    const progress = Math.max(0, Math.min(value / 10, 1));
+    setOffset(circumference * (1 - progress));
+  }, [value, circumference]);
+
+  return (
+    <svg width={size} height={size} className="text-accent">
+      <circle
+        stroke="var(--muted)"
+        strokeWidth={stroke}
+        fill="transparent"
+        r={radius}
+        cx={size / 2}
+        cy={size / 2}
+      />
+      <circle
+        stroke="var(--accent)"
+        strokeWidth={stroke}
+        fill="transparent"
+        r={radius}
+        cx={size / 2}
+        cy={size / 2}
+        strokeDasharray={circumference}
+        strokeDashoffset={offset}
+        className="origin-center -rotate-90 transform transition-all duration-500 ease-out"
+      />
+      <text
+        x="50%"
+        y="50%"
+        dominantBaseline="middle"
+        textAnchor="middle"
+        className="fill-text text-xl font-bold"
+      >
+        {value.toFixed(1)}
+      </text>
+    </svg>
+  );
+}

--- a/src/components/FadeIn.tsx
+++ b/src/components/FadeIn.tsx
@@ -1,0 +1,42 @@
+'use client';
+import { useEffect, useRef, useState, ReactNode } from 'react';
+
+interface FadeInProps {
+  children: ReactNode;
+  className?: string;
+}
+
+export default function FadeIn({ children, className = '' }: FadeInProps) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      setVisible(true);
+      return;
+    }
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setVisible(true);
+          observer.disconnect();
+        }
+      },
+      { threshold: 0.2 }
+    );
+    if (ref.current) observer.observe(ref.current);
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <div
+      ref={ref}
+      className={`transform transition-all duration-300 ease-out motion-reduce:transition-none ${
+        visible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-2'
+      } ${className}`}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,0 +1,101 @@
+import ImageCarousel from './ImageCarousel';
+import CircularScore from './CircularScore';
+import StatPill from './StatPill';
+
+interface HeroProps {
+  title: string;
+  subtitle?: string;
+  tags?: string[];
+  images: string[];
+  releaseDate?: string | null;
+  publisher?: string | null;
+  rating?: string | null;
+  score?: number | null;
+}
+
+export default function Hero({
+  title,
+  subtitle,
+  tags = [],
+  images,
+  releaseDate,
+  publisher,
+  rating,
+  score,
+}: HeroProps) {
+  return (
+    <section className="relative text-text">
+      <ImageCarousel images={images} alt={title} />
+      <div className="absolute inset-0 bg-gradient-to-t from-bg/90 to-bg/30" />
+      {score !== null && score !== undefined && (
+        <div className="absolute right-4 top-4">
+          <CircularScore value={score} size={80} />
+        </div>
+      )}
+      <div className="absolute bottom-4 left-4 space-y-3">
+        <h1 className="text-3xl font-bold leading-tight">{title}</h1>
+        {subtitle && <p className="text-text-muted">{subtitle}</p>}
+        {tags.length > 0 && (
+          <div className="mt-2 flex flex-wrap gap-2">
+            {tags.map((tag) => (
+              <span
+                key={tag}
+                className="rounded-full bg-surface px-3 py-1 text-xs"
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+        )}
+        <div className="flex flex-wrap gap-2 text-xs">
+          {releaseDate && (
+            <StatPill
+              icon={
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24"
+                  fill="currentColor"
+                  className="h-4 w-4"
+                >
+                  <path d="M6.75 3v2.25m10.5-2.25V5.25M3 18.75V7.5a2.25 2.25 0 0 1 2.25-2.25h13.5A2.25 2.25 0 0 1 21 7.5v11.25A2.25 2.25 0 0 1 18.75 21H5.25A2.25 2.25 0 0 1 3 18.75z" />
+                  <path d="M3 10.5h18" />
+                </svg>
+              }
+              label={releaseDate}
+            />
+          )}
+          {publisher && (
+            <StatPill
+              icon={
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24"
+                  fill="currentColor"
+                  className="h-4 w-4"
+                >
+                  <path d="M12 2.25c-5.385 0-9.75 4.365-9.75 9.75s4.365 9.75 9.75 9.75 9.75-4.365 9.75-9.75S17.385 2.25 12 2.25zm0 3a6.75 6.75 0 1 1 0 13.5 6.75 6.75 0 0 1 0-13.5z" />
+                </svg>
+              }
+              label={publisher}
+            />
+          )}
+          {rating && (
+            <StatPill
+              icon={
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24"
+                  fill="currentColor"
+                  className="h-4 w-4"
+                >
+                  <path d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z" />
+                </svg>
+              }
+              label={rating}
+            />
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/ImageCarousel.tsx
+++ b/src/components/ImageCarousel.tsx
@@ -1,0 +1,93 @@
+'use client';
+import Image from 'next/image';
+import { useRef, useState } from 'react';
+
+interface ImageCarouselProps {
+  images: string[];
+  alt?: string;
+}
+
+export default function ImageCarousel({ images, alt = '' }: ImageCarouselProps) {
+  const hasImages = images && images.length > 0;
+  const [index, setIndex] = useState(0);
+  const startX = useRef<number | null>(null);
+
+  const prev = () => setIndex((i) => (i - 1 + images.length) % images.length);
+  const next = () => setIndex((i) => (i + 1) % images.length);
+
+  const onTouchStart = (e: React.TouchEvent) => {
+    startX.current = e.touches[0].clientX;
+  };
+  const onTouchEnd = (e: React.TouchEvent) => {
+    if (startX.current === null) return;
+    const diff = e.changedTouches[0].clientX - startX.current;
+    if (Math.abs(diff) > 50) {
+      if (diff > 0) {
+        prev();
+      } else {
+        next();
+      }
+    }
+    startX.current = null;
+  };
+
+  if (!hasImages) {
+    return (
+      <div className="flex h-64 items-center justify-center bg-surface text-text-muted">No image</div>
+    );
+  }
+
+  return (
+    <div className="relative" onTouchStart={onTouchStart} onTouchEnd={onTouchEnd}>
+      <div className="relative h-64 overflow-hidden">
+        {images.map((src, i) => (
+          <Image
+            key={src}
+            src={src}
+            alt={alt}
+            fill
+            className={`absolute inset-0 h-full w-full object-cover transition-transform duration-300 ease-out ${
+              i === index ? 'translate-x-0' : i < index ? '-translate-x-full' : 'translate-x-full'
+            }`}
+            sizes="100vw"
+            priority={i === 0}
+          />
+        ))}
+      </div>
+      {images.length > 1 && (
+        <>
+          <button
+            aria-label="Previous image"
+            onClick={prev}
+            className="absolute left-2 top-1/2 -translate-y-1/2 rounded-full bg-bg/60 p-2 text-text hover:bg-bg/80 focus:outline-none focus:ring-2 focus:ring-accent"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="h-5 w-5">
+              <path d="M15.75 19.5 8.25 12l7.5-7.5" />
+            </svg>
+          </button>
+          <button
+            aria-label="Next image"
+            onClick={next}
+            className="absolute right-2 top-1/2 -translate-y-1/2 rounded-full bg-bg/60 p-2 text-text hover:bg-bg/80 focus:outline-none focus:ring-2 focus:ring-accent"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="h-5 w-5">
+              <path d="m8.25 4.5 7.5 7.5-7.5 7.5" />
+            </svg>
+          </button>
+          <div className="absolute bottom-2 left-1/2 flex -translate-x-1/2 gap-1">
+            {images.map((_, i) => (
+              <button
+                key={i}
+                aria-label={`Go to slide ${i + 1}`}
+                onClick={() => setIndex(i)}
+                className={`h-2 w-2 rounded-full ${
+                  i === index ? 'bg-accent' : 'bg-muted'
+                }`}
+              />
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/ProsCons.tsx
+++ b/src/components/ProsCons.tsx
@@ -1,0 +1,64 @@
+import Card from './Card';
+
+interface ProsConsProps {
+  pros: string[];
+  cons: string[];
+}
+
+function List({ items, icon }: { items: string[]; icon: JSX.Element }) {
+  if (!items || items.length === 0) {
+    return <p className="text-text-muted">No data yet.</p>;
+  }
+  return (
+    <ul className="flex flex-wrap gap-2">
+      {items.map((item) => (
+        <li
+          key={item}
+          className="flex items-center gap-1 rounded-full bg-surface px-3 py-1 text-sm"
+        >
+          {icon}
+          {item}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+export default function ProsCons({ pros, cons }: ProsConsProps) {
+  return (
+    <div className="grid gap-4 md:grid-cols-2">
+      <Card accent="good">
+        {pros.length > 0 && <h3 className="mb-2 font-semibold">Pros</h3>}
+        <List
+          items={pros}
+          icon={
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="currentColor"
+              className="h-4 w-4 text-good"
+            >
+              <path d="M9 12.75 11.25 15 15 9.75" stroke="currentColor" strokeWidth="2" fill="none" />
+            </svg>
+          }
+        />
+      </Card>
+      <Card accent="bad">
+        {cons.length > 0 && <h3 className="mb-2 font-semibold">Cons</h3>}
+        <List
+          items={cons}
+          icon={
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="currentColor"
+              className="h-4 w-4 text-bad"
+            >
+              <path d="M15 9 9 15m0-6 6 6" stroke="currentColor" strokeWidth="2" fill="none" />
+            </svg>
+          }
+        />
+      </Card>
+    </div>
+  );
+}

--- a/src/components/Section.tsx
+++ b/src/components/Section.tsx
@@ -1,0 +1,18 @@
+import { ReactNode } from 'react';
+import FadeIn from './FadeIn';
+
+interface SectionProps {
+  title: string;
+  children: ReactNode;
+}
+
+export default function Section({ title, children }: SectionProps) {
+  return (
+    <FadeIn className="my-12">
+      <section>
+        <h2 className="mb-4 text-2xl font-bold">{title}</h2>
+        {children}
+      </section>
+    </FadeIn>
+  );
+}

--- a/src/components/StatPill.tsx
+++ b/src/components/StatPill.tsx
@@ -1,0 +1,15 @@
+import { ReactNode } from 'react';
+
+interface StatPillProps {
+  icon: ReactNode;
+  label: string;
+}
+
+export default function StatPill({ icon, label }: StatPillProps) {
+  return (
+    <span className="inline-flex items-center gap-1 rounded-full bg-surface px-3 py-1 text-sm text-text-muted">
+      {icon}
+      {label}
+    </span>
+  );
+}


### PR DESCRIPTION
## Summary
- add gaming-themed color palette tokens for Tailwind
- implement reusable Game Details components with animations and carousel
- rebuild game details page using new sections and score indicator

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac5bb68798832ba8f206758885cfd0