### PR TITLE
Decode slug for game page and metadata

### DIFF
--- a/src/app/games/[slug]/page.tsx
+++ b/src/app/games/[slug]/page.tsx
@@ -7,7 +7,7 @@ export const revalidate = 86400;      // 1 Tag
 export const dynamicParams = true;    // neue Slugs sofort möglich
 
 export async function generateMetadata({ params }: { params: Promise<{ slug: string }> }) {
-  const { slug } = await params;
+  const slug = decodeURIComponent((await params).slug);
   const game = await getGameBySlug(slug);
   if (!game) return {};
   return {
@@ -19,7 +19,7 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
 }
 
 export default async function Page({ params }: { params: Promise<{ slug: string }> }) {
-  const { slug } = await params;
+  const slug = decodeURIComponent((await params).slug);
   const game = await getGameBySlug(slug);
   if (!game) return notFound();
 


### PR DESCRIPTION
## Summary
- Decode slug from route params before fetching game data
- Pass decoded slug to `getGameBySlug` in page and metadata generation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad6b353ccc832b901060751727764c