### PR TITLE
Link tag chips to tag pages

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -115,12 +115,13 @@ export default async function Page() {
 
                   <div className="flex flex-wrap items-center gap-2 p-[var(--space-4)] sm:p-[var(--space-5)]">
                     {(featured.tags ?? []).slice(0, 4).map((t) => (
-                      <span
+                      <Link
                         key={t}
+                        href={`/tags/${encodeURIComponent(t)}`}
                         className="rounded-full bg-gray-100 px-2.5 py-1 text-[11px] font-medium text-gray-800 dark:bg-gray-800 dark:text-gray-200"
                       >
                         {t}
-                      </span>
+                      </Link>
                     ))}
                     <span className="ml-auto inline-flex items-center gap-1 text-sm font-medium text-indigo-600 transition group-hover:translate-x-0.5 dark:text-sky-400">
                       Read review
@@ -168,12 +169,13 @@ export default async function Page() {
                       {!!(x.tags?.length) && (
                         <div className="mt-3 flex flex-wrap gap-2">
                           {x.tags!.slice(0, 3).map((t) => (
-                            <span
+                            <Link
                               key={t}
+                              href={`/tags/${encodeURIComponent(t)}`}
                               className="rounded-full bg-gray-100 px-2.5 py-1 text-[11px] font-medium text-gray-800 dark:bg-gray-800 dark:text-gray-200"
                             >
                               {t}
-                            </span>
+                            </Link>
                           ))}
                         </div>
                       )}
@@ -219,12 +221,13 @@ export default async function Page() {
                       {!!(x.tags?.length) && (
                         <div className="mt-3 flex flex-wrap gap-2">
                           {x.tags!.slice(0, 3).map((t) => (
-                            <span
+                            <Link
                               key={t}
+                              href={`/tags/${encodeURIComponent(t)}`}
                               className="rounded-full bg-gray-100 px-2.5 py-1 text-[11px] font-medium text-gray-800 dark:bg-gray-800 dark:text-gray-200"
                             >
                               {t}
-                            </span>
+                            </Link>
                           ))}
                         </div>
                       )}

--- a/src/components/GameHero.tsx
+++ b/src/components/GameHero.tsx
@@ -1,4 +1,5 @@
 import Image from 'next/image';
+import Link from 'next/link';
 import { useMemo } from 'react';
 import { CalendarDays, Gamepad2 } from 'lucide-react';
 
@@ -92,12 +93,13 @@ export default function GameHero({
               {!!tags.length && (
                 <div className="mt-6 flex flex-wrap gap-2">
                   {tags.map((t) => (
-                    <span
+                    <Link
                       key={t}
+                      href={`/tags/${encodeURIComponent(t)}`}
                       className="rounded-full border border-transparent bg-gray-100 px-3 py-1 text-xs font-medium text-gray-800 shadow-sm transition-colors hover:border-gray-300 dark:bg-gray-800 dark:text-gray-200"
                     >
                       {t}
-                    </span>
+                    </Link>
                   ))}
                 </div>
               )}


### PR DESCRIPTION
## Summary
- Replace tag chips with Links pointing to encoded tag pages in GameHero and homepage listings

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad76310650832ba4ae1c5c1c6f8519