### PR TITLE
Add tag review listing with sorting

### DIFF
--- a/src/app/tags/[tag]/SortSelect.tsx
+++ b/src/app/tags/[tag]/SortSelect.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { useRouter, useSearchParams } from 'next/navigation';
+
+const options = [
+  { value: 'publishedAt', label: 'Newest' },
+  { value: 'score', label: 'Score' },
+  { value: 'title', label: 'Title' },
+];
+
+export default function SortSelect() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const current = searchParams.get('sort') ?? 'publishedAt';
+
+  return (
+    <select
+      value={current}
+      onChange={(e) => {
+        const params = new URLSearchParams(searchParams.toString());
+        params.set('sort', e.target.value);
+        router.replace(`?${params.toString()}`);
+      }}
+      className="rounded-md border p-2 text-sm"
+    >
+      {options.map((o) => (
+        <option key={o.value} value={o.value}>
+          {o.label}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/src/app/tags/[tag]/page.tsx
+++ b/src/app/tags/[tag]/page.tsx
@@ -3,8 +3,27 @@ import Link from 'next/link';
 import SortSelect from './SortSelect';
 import { getReviewsByTag } from '@/lib/queries';
 
-function coverOf(heroUrl?: string | null) {
-  return heroUrl || 'https://placehold.co/1200x675.png';
+type ReviewItem = {
+  slug: string;
+  title: string;
+  heroUrl?: string | null;
+  images?: string[] | null;
+  score?: number | null;
+  releaseDate?: Date | string | null;
+};
+
+function scoreClasses(score?: number | null) {
+  if (typeof score !== 'number')
+    return 'bg-gray-200 text-gray-700 dark:bg-gray-800 dark:text-gray-300';
+  if (score >= 9)
+    return 'bg-emerald-500/15 text-emerald-700 ring-1 ring-emerald-400/40 dark:text-emerald-300';
+  if (score >= 8)
+    return 'bg-amber-500/15  text-amber-700  ring-1 ring-amber-400/40  dark:text-amber-300';
+  return 'bg-rose-500/15    text-rose-700    ring-1 ring-rose-400/40    dark:text-rose-300';
+}
+
+function coverOf(x: ReviewItem) {
+  return x.images?.[0] || x.heroUrl || 'https://placehold.co/1200x675.png';
 }
 
 export default async function Page({
@@ -21,6 +40,14 @@ export default async function Page({
     : 'publishedAt';
 
   const rows = await getReviewsByTag(decodeURIComponent(params.tag), order);
+  const items: ReviewItem[] = rows.map((r) => ({
+    slug: r.slug,
+    title: r.title,
+    heroUrl: r.heroUrl,
+    images: r.images ? [r.images] : null,
+    score: r.score != null ? Number(r.score) : null,
+    releaseDate: r.releaseDate,
+  }));
 
   return (
     <main className="mx-auto max-w-screen-xl px-[var(--container-x)] pt-[var(--section-pt)] pb-[var(--section-pb)] 2xl:px-0">
@@ -31,7 +58,7 @@ export default async function Page({
         <SortSelect />
       </header>
       <ul className="grid gap-[var(--block-gap)] sm:grid-cols-2 lg:grid-cols-3">
-        {rows.map((r) => (
+        {items.map((r) => (
           <li key={r.slug} className="group">
             <Link
               href={`/games/${r.slug}`}
@@ -39,14 +66,18 @@ export default async function Page({
             >
               <div className="relative">
                 <Image
-                  src={coverOf(r.heroUrl)}
+                  src={coverOf(r)}
                   alt={r.title ?? 'cover image'}
                   width={1200}
                   height={675}
                   className="h-40 w-full object-cover transition-transform duration-500 group-hover:scale-[1.03]"
                 />
-                <span className="absolute right-4 top-4 rounded-full bg-white/80 px-2.5 py-1 text-[11px] font-semibold backdrop-blur">
-                  {typeof r.score === 'number' ? Number(r.score).toFixed(1) : '–'}
+                <span
+                  className={`absolute right-4 top-4 rounded-full px-2.5 py-1 text-[11px] font-semibold backdrop-blur ${scoreClasses(
+                    r.score,
+                  )}`}
+                >
+                  {typeof r.score === 'number' ? r.score.toFixed(1) : '–'}
                 </span>
               </div>
               <div className="p-[var(--space-4)]">

--- a/src/app/tags/[tag]/page.tsx
+++ b/src/app/tags/[tag]/page.tsx
@@ -1,0 +1,72 @@
+import Image from 'next/image';
+import Link from 'next/link';
+import SortSelect from './SortSelect';
+import { getReviewsByTag } from '@/lib/queries';
+
+function coverOf(heroUrl?: string | null) {
+  return heroUrl || 'https://placehold.co/1200x675.png';
+}
+
+export default async function Page({
+  params,
+  searchParams,
+}: {
+  params: { tag: string };
+  searchParams: { sort?: string };
+}) {
+  const order = ['score', 'publishedAt', 'title'].includes(
+    searchParams.sort ?? ''
+  )
+    ? (searchParams.sort as 'score' | 'publishedAt' | 'title')
+    : 'publishedAt';
+
+  const rows = await getReviewsByTag(decodeURIComponent(params.tag), order);
+
+  return (
+    <main className="mx-auto max-w-screen-xl px-[var(--container-x)] pt-[var(--section-pt)] pb-[var(--section-pb)] 2xl:px-0">
+      <header className="mb-[var(--space-8)] flex items-center gap-4">
+        <h1 className="text-3xl font-bold tracking-tight">
+          {decodeURIComponent(params.tag)}
+        </h1>
+        <SortSelect />
+      </header>
+      <ul className="grid gap-[var(--block-gap)] sm:grid-cols-2 lg:grid-cols-3">
+        {rows.map((r) => (
+          <li key={r.slug} className="group">
+            <Link
+              href={`/games/${r.slug}`}
+              className="block overflow-hidden rounded-3xl border bg-white/60 shadow-sm ring-1 ring-black/5 transition hover:shadow-lg dark:bg-gray-900/60"
+            >
+              <div className="relative">
+                <Image
+                  src={coverOf(r.heroUrl)}
+                  alt={r.title ?? 'cover image'}
+                  width={1200}
+                  height={675}
+                  className="h-40 w-full object-cover transition-transform duration-500 group-hover:scale-[1.03]"
+                />
+                <span className="absolute right-4 top-4 rounded-full bg-white/80 px-2.5 py-1 text-[11px] font-semibold backdrop-blur">
+                  {typeof r.score === 'number' ? Number(r.score).toFixed(1) : '–'}
+                </span>
+              </div>
+              <div className="p-[var(--space-4)]">
+                <h3 className="line-clamp-1 text-lg font-semibold tracking-tight text-gray-900 dark:text-white">
+                  {r.title}
+                </h3>
+                {r.releaseDate && (
+                  <p className="mt-1 text-sm text-gray-600 dark:text-gray-300">
+                    {new Date(r.releaseDate).toLocaleDateString('en-US', {
+                      year: 'numeric',
+                      month: 'short',
+                      day: 'numeric',
+                    })}
+                  </p>
+                )}
+              </div>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -139,11 +139,20 @@ export async function getReviewsByTag(
             ? games.title
             : reviews.publishedAt;
 
+    const coverImageSubquery = sql<string>`(
+        select gi.url
+        from game_images as gi
+        where gi.game_id = ${games.id}
+        order by gi.sort_order nulls last, gi.id
+        limit 1
+    )`;
+
     return db
         .select({
             slug: games.slug,
             title: games.title,
             heroUrl: games.heroUrl,
+            images: coverImageSubquery,
             score: reviews.score,
             publishedAt: reviews.publishedAt,
             releaseDate: games.releaseDate,

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -127,3 +127,31 @@ export async function getGameBySlug(slug: string) {
         ),
     };
 }
+
+export async function getReviewsByTag(
+    tag: string,
+    orderBy: 'score' | 'publishedAt' | 'title' = 'publishedAt'
+) {
+    const orderColumn =
+        orderBy === 'score'
+            ? reviews.score
+            : orderBy === 'title'
+            ? games.title
+            : reviews.publishedAt;
+
+    return db
+        .select({
+            slug: games.slug,
+            title: games.title,
+            heroUrl: games.heroUrl,
+            score: reviews.score,
+            publishedAt: reviews.publishedAt,
+            releaseDate: games.releaseDate,
+        })
+        .from(reviews)
+        .innerJoin(reviewTags, eq(reviewTags.reviewId, reviews.id))
+        .innerJoin(tags, eq(reviewTags.tagId, tags.id))
+        .innerJoin(games, eq(reviews.gameId, games.id))
+        .where(eq(tags.name, tag))
+        .orderBy(orderBy === 'title' ? orderColumn : desc(orderColumn));
+}


### PR DESCRIPTION
## Summary
- query reviews by tag with configurable ordering
- add tag page showing review cards linking to games
- client SortSelect updates URL to resort results

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad80db8690832b8c7163f1fcc8b3a2