### PR TITLE
Add lightbox gallery to game articles

### DIFF
--- a/src/components/Lightbox.tsx
+++ b/src/components/Lightbox.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useEffect, useState } from 'react';
+import Image from 'next/image';
+
+interface LightboxImage {
+  src: string;
+  caption?: string;
+}
+
+interface LightboxProps {
+  images: LightboxImage[];
+  startIndex: number;
+  onClose: () => void;
+}
+
+export default function Lightbox({ images, startIndex, onClose }: LightboxProps) {
+  const [index, setIndex] = useState(startIndex);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+      if (e.key === 'ArrowRight') setIndex((i) => (i + 1) % images.length);
+      if (e.key === 'ArrowLeft') setIndex((i) => (i - 1 + images.length) % images.length);
+    };
+    window.addEventListener('keydown', onKey);
+    document.body.style.overflow = 'hidden';
+    return () => {
+      window.removeEventListener('keydown', onKey);
+      document.body.style.overflow = '';
+    };
+  }, [images.length, onClose]);
+
+  const img = images[index];
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-4"
+      onClick={onClose}
+    >
+      <figure className="relative max-h-full max-w-full" onClick={(e) => e.stopPropagation()}>
+        <Image
+          src={img.src}
+          alt={img.caption ?? `Screenshot ${index + 1}`}
+          width={1280}
+          height={720}
+          className="h-auto max-h-full w-auto max-w-full"
+        />
+        {img.caption && (
+          <figcaption className="mt-2 text-center text-sm text-white">{img.caption}</figcaption>
+        )}
+      </figure>
+      {images.length > 1 && (
+        <>
+          <button
+            className="absolute left-4 top-1/2 -translate-y-1/2 rounded-full bg-black/50 p-2 text-white"
+            onClick={(e) => {
+              e.stopPropagation();
+              setIndex((i) => (i - 1 + images.length) % images.length);
+            }}
+            aria-label="Previous image"
+          >
+            ‹
+          </button>
+          <button
+            className="absolute right-4 top-1/2 -translate-y-1/2 rounded-full bg-black/50 p-2 text-white"
+            onClick={(e) => {
+              e.stopPropagation();
+              setIndex((i) => (i + 1) % images.length);
+            }}
+            aria-label="Next image"
+          >
+            ›
+          </button>
+        </>
+      )}
+      <button
+        className="absolute right-4 top-4 rounded-full bg-black/50 p-2 text-white"
+        onClick={(e) => {
+          e.stopPropagation();
+          onClose();
+        }}
+        aria-label="Close"
+      >
+        ✕
+      </button>
+    </div>
+  );
+}

--- a/src/components/MainArticle.tsx
+++ b/src/components/MainArticle.tsx
@@ -1,4 +1,8 @@
+"use client";
+
 import Image from 'next/image';
+import { useState } from 'react';
+import Lightbox from './Lightbox';
 
 interface MainArticleProps {
   reviewTitle: string | null;
@@ -8,7 +12,7 @@ interface MainArticleProps {
   conclusion: string | null;
   score: number | null;
   userOpinion: string | null;
-  images?: string[];
+  images?: Array<string | { src: string; caption?: string }>;
   pros?: string[];
   cons?: string[];
 }
@@ -25,6 +29,12 @@ export default function MainArticle({
   pros = [],
   cons = [],
 }: MainArticleProps) {
+  const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
+
+  const galleryImages = images.slice(1, 4).map((img) =>
+    typeof img === 'string' ? { src: img } : img,
+  );
+
   return (
     <article id="main" className="mx-auto max-w-3xl px-4 pb-16">
       <header className="mb-8">
@@ -36,18 +46,27 @@ export default function MainArticle({
         )}
       </header>
 
-      {images.length > 1 && (
+      {!!galleryImages.length && (
         <div className="mb-8 grid grid-cols-2 gap-3 sm:grid-cols-3">
-          {images.slice(1, 4).map((img, idx) => (
-            <div key={img} className="overflow-hidden rounded-2xl shadow ring-1 ring-black/5">
+          {galleryImages.map((img, idx) => (
+            <figure
+              key={img.src}
+              className="group cursor-pointer overflow-hidden rounded-2xl shadow ring-1 ring-black/5"
+              onClick={() => setLightboxIndex(idx)}
+            >
               <Image
-                src={img}
+                src={img.src}
                 alt={`Screenshot ${idx + 1}`}
                 width={640}
                 height={360}
-                className="h-full w-full object-cover transition-transform duration-500 hover:scale-[1.03]"
+                className="h-full w-full object-cover transition-transform duration-500 group-hover:scale-[1.03]"
               />
-            </div>
+              {img.caption && (
+                <figcaption className="bg-black/60 p-2 text-xs text-white">
+                  {img.caption}
+                </figcaption>
+              )}
+            </figure>
           ))}
         </div>
       )}
@@ -111,6 +130,13 @@ export default function MainArticle({
             {userOpinion}
           </blockquote>
         </section>
+      )}
+      {lightboxIndex !== null && (
+        <Lightbox
+          images={galleryImages}
+          startIndex={lightboxIndex}
+          onClose={() => setLightboxIndex(null)}
+        />
       )}
     </article>
   );


### PR DESCRIPTION
## Summary
- replace screenshot grid with clickable figures
- add Lightbox component for modal gallery with captions

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Geist` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68ad89b5a48c832bb49b022a77b513e3