### PR TITLE
Add similar games sidebar and query

### DIFF
--- a/src/app/games/[slug]/page.tsx
+++ b/src/app/games/[slug]/page.tsx
@@ -1,7 +1,8 @@
-import { getGameBySlug } from '@/lib/queries';
+import { getGameBySlug, getSimilarGames } from '@/lib/queries';
 import { notFound } from 'next/navigation';
 import GameHero from '@/components/GameHero';
 import MainArticle from '@/components/MainArticle';
+import SimilarGames from '@/components/SimilarGames';
 
 export const revalidate = 86400;      // 1 Tag
 export const dynamicParams = true;    // neue Slugs sofort möglich
@@ -19,34 +20,38 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
 }
 
 export default async function Page({ params }: { params: Promise<{ slug: string }> }) {
-  const slug = decodeURIComponent((await params).slug);
-  const game = await getGameBySlug(slug);
-  if (!game) return notFound();
+    const slug = decodeURIComponent((await params).slug);
+    const game = await getGameBySlug(slug);
+    if (!game) return notFound();
+    const similarGames = await getSimilarGames(slug);
 
-  return (
-    <>
-      <GameHero
-        title={game.title}
-        developer={game.developer}
-        tags={game.tags ?? []}
-        platforms={game.platforms ?? []}
-        score={game.score ? Number(game.score) : null}
-        heroUrl={game.heroUrl ?? undefined}
-        images={game.images ?? []}
-        releaseDate={game.releaseDate ? new Date(game.releaseDate).toLocaleDateString('de-DE', { year: 'numeric', month: 'long', day: 'numeric' }) : undefined}
-      />
-      <MainArticle
-        reviewTitle={game.reviewTitle}
-        description={game.description}
-        introduction={game.introduction}
-        gameplayFeatures={game.gameplayFeatures}
-        conclusion={game.conclusion}
-        score={game.score ? Number(game.score) : null}
-        userOpinion={game.userOpinion}
-        images={game.images ?? []}
-        pros={game.pros ?? []}
-        cons={game.cons ?? []}
-      />
-    </>
-  );
+    return (
+      <>
+        <GameHero
+          title={game.title}
+          developer={game.developer}
+          tags={game.tags ?? []}
+          platforms={game.platforms ?? []}
+          score={game.score ? Number(game.score) : null}
+          heroUrl={game.heroUrl ?? undefined}
+          images={game.images ?? []}
+          releaseDate={game.releaseDate ? new Date(game.releaseDate).toLocaleDateString('de-DE', { year: 'numeric', month: 'long', day: 'numeric' }) : undefined}
+        />
+        <div className={`mx-auto grid gap-8 px-4 ${similarGames.length ? 'lg:grid-cols-[minmax(0,1fr)_300px]' : ''}`}>
+          <MainArticle
+            reviewTitle={game.reviewTitle}
+            description={game.description}
+            introduction={game.introduction}
+            gameplayFeatures={game.gameplayFeatures}
+            conclusion={game.conclusion}
+            score={game.score ? Number(game.score) : null}
+            userOpinion={game.userOpinion}
+            images={game.images ?? []}
+            pros={game.pros ?? []}
+            cons={game.cons ?? []}
+          />
+          {similarGames.length > 0 && <SimilarGames games={similarGames} />}
+        </div>
+      </>
+    );
 }

--- a/src/components/MainArticle.tsx
+++ b/src/components/MainArticle.tsx
@@ -13,8 +13,9 @@ interface MainArticleProps {
   score: number | null;
   userOpinion: string | null;
   images?: Array<string | { src: string; caption?: string }>;
-  pros?: string[];
-  cons?: string[];
+    pros?: string[];
+    cons?: string[];
+    className?: string;
 }
 
 export default function MainArticle({
@@ -25,9 +26,10 @@ export default function MainArticle({
   conclusion,
   score,
   userOpinion,
-  images = [],
-  pros = [],
-  cons = [],
+    images = [],
+    pros = [],
+    cons = [],
+    className,
 }: MainArticleProps) {
   const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
 
@@ -35,8 +37,8 @@ export default function MainArticle({
     typeof img === 'string' ? { src: img } : img,
   );
 
-  return (
-    <article id="main" className="mx-auto max-w-3xl px-4 pb-16">
+    return (
+      <article id="main" className={`px-4 pb-16 ${className ?? ''}`}>
       <header className="mb-8">
         <h2 className="mb-3 bg-gradient-to-r from-indigo-600 via-sky-500 to-fuchsia-500 bg-clip-text text-3xl font-extrabold tracking-tight text-transparent sm:text-4xl">
           {reviewTitle}

--- a/src/components/SimilarGames.tsx
+++ b/src/components/SimilarGames.tsx
@@ -1,0 +1,49 @@
+import Image from 'next/image';
+import Link from 'next/link';
+
+interface SimilarGame {
+  slug: string;
+  title: string;
+  heroUrl?: string | null;
+  images?: string | null;
+}
+
+interface SimilarGamesProps {
+  games: SimilarGame[];
+}
+
+export default function SimilarGames({ games }: SimilarGamesProps) {
+  if (!games.length) return null;
+
+  return (
+    <aside className="w-full lg:col-start-2 lg:w-[300px] lg:sticky lg:top-4">
+      <h3 className="mb-4 text-lg font-semibold">Ähnliche Spiele</h3>
+      <ul className="grid gap-4">
+        {games.map((game) => {
+          const imageUrl = game.images ?? game.heroUrl;
+          return (
+            <li
+              key={game.slug}
+              className="overflow-hidden rounded-xl border bg-white/60 shadow-sm ring-1 ring-black/5 dark:bg-gray-900/60"
+            >
+              <Link href={`/games/${game.slug}`} className="flex gap-3 p-3">
+                {imageUrl && (
+                  <Image
+                    src={imageUrl}
+                    alt={game.title}
+                    width={80}
+                    height={45}
+                    className="h-16 w-24 flex-none rounded-md object-cover"
+                  />
+                )}
+                <span className="self-center text-sm font-medium leading-tight">
+                  {game.title}
+                </span>
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </aside>
+  );
+}

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -147,6 +147,8 @@ export async function getSimilarGames(slug: string, limit = 4) {
         limit 1
     )`;
 
+    const matchCount = sql<number>`count(distinct ${reviewTags.tagId})`;
+
     return db
         .select({
             slug: games.slug,
@@ -165,6 +167,7 @@ export async function getSimilarGames(slug: string, limit = 4) {
             )
         )
         .groupBy(games.id, games.slug, games.title, games.heroUrl)
+        .orderBy(desc(matchCount))
         .limit(limit);
 }
 


### PR DESCRIPTION
## Summary
- query similar games by shared tags and return cover images
- display similar games in new sidebar component
- allow MainArticle width to be controlled by parent and layout review page grid

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68aeb18e71b8832bad63f38279deae4b