### PR TITLE
test: add query tests with node test runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,17 @@ npm run dev
 # http://localhost:3000
 ```
 
+### Tests ausführen
+```bash
+npm test
+```
+
 ## Wichtige Skripte
 - `dev`: Development‑Server (Turbopack)
 - `build`: Production‑Build (Turbopack)
 - `start`: Production‑Server starten
 - `lint`: ESLint ausführen
+- `test`: Tests mit dem Node-Test-Runner über `tsx`
 - `db:generate`: Drizzle‑Migrationen aus dem Schema erzeugen
 - `db:migrate`: Drizzle‑Migrationen anwenden
 - `db:push`: Schema direkt gegen die DB synchronisieren

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build --turbopack",
     "start": "next start",
     "lint": "eslint",
+    "test": "tsx --test src/**/*.test.ts",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
     "db:push": "drizzle-kit push"

--- a/src/lib/queries.test.ts
+++ b/src/lib/queries.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { db } from './db';
+import {
+  getRecentReviews,
+  getGameBySlug,
+  getSimilarGames,
+} from './queries';
+
+const originalSelect = db.select;
+
+type QueryChain = {
+  from: () => QueryChain;
+  leftJoin: () => QueryChain;
+  innerJoin: () => QueryChain;
+  where: () => QueryChain;
+  orderBy: () => QueryChain;
+  groupBy: () => QueryChain;
+  limit: () => QueryChain;
+  then: (resolve: (value: unknown) => unknown) => Promise<unknown>;
+};
+
+function mockSelect(responses: unknown[]): () => QueryChain {
+  return () => {
+    const data = responses.shift();
+    const chain: QueryChain = {
+      from: () => chain,
+      leftJoin: () => chain,
+      innerJoin: () => chain,
+      where: () => chain,
+      orderBy: () => chain,
+      groupBy: () => chain,
+      limit: () => chain,
+      then: (resolve) => Promise.resolve(data).then(resolve),
+    };
+    return chain;
+  };
+}
+
+beforeEach(() => {
+  db.select = originalSelect;
+});
+
+describe('queries', () => {
+  it('getRecentReviews returns recent reviews', async () => {
+    const recent = [
+      {
+        slug: 'game-1',
+        title: 'Game 1',
+        summary: 'Summary',
+        heroUrl: 'hero1',
+        score: 90,
+        publishedAt: new Date('2024-01-01'),
+        images: 'img1',
+      },
+    ];
+    db.select = mockSelect([recent]);
+    assert.deepStrictEqual(await getRecentReviews(), recent);
+  });
+
+  it('getGameBySlug formats game data', async () => {
+    const rows = [
+      {
+        id: 1,
+        slug: 'game',
+        title: 'Game',
+        summary: 'Summary',
+        heroUrl: 'hero',
+        releaseDate: '2024-01-01',
+        reviewTitle: 'Review',
+        description: 'Desc',
+        introduction: 'Intro',
+        gameplayFeatures: 'Features',
+        conclusion: 'Conclusion',
+        score: 85,
+        developer: 'Dev',
+        tagName: 'Action',
+        platformName: 'PC',
+        userOpinion: 'Great',
+        images: 'img1',
+        proConText: 'Good',
+        proConType: 'pro',
+      },
+      {
+        id: 1,
+        slug: 'game',
+        title: 'Game',
+        summary: 'Summary',
+        heroUrl: 'hero',
+        releaseDate: '2024-01-01',
+        reviewTitle: 'Review',
+        description: 'Desc',
+        introduction: 'Intro',
+        gameplayFeatures: 'Features',
+        conclusion: 'Conclusion',
+        score: 85,
+        developer: 'Dev',
+        tagName: 'RPG',
+        platformName: 'Xbox',
+        userOpinion: 'Great',
+        images: 'img2',
+        proConText: 'Bad',
+        proConType: 'con',
+      },
+    ];
+    db.select = mockSelect([rows]);
+    assert.deepStrictEqual(await getGameBySlug('game'), {
+      id: 1,
+      slug: 'game',
+      title: 'Game',
+      summary: 'Summary',
+      heroUrl: 'hero',
+      description: 'Desc',
+      introduction: 'Intro',
+      gameplayFeatures: 'Features',
+      conclusion: 'Conclusion',
+      score: 85,
+      developer: 'Dev',
+      releaseDate: '2024-01-01',
+      tags: ['Action', 'RPG'],
+      platforms: ['PC', 'Xbox'],
+      images: ['img1', 'img2'],
+      userOpinion: 'Great',
+      reviewTitle: 'Review',
+      pros: ['Good'],
+      cons: ['Bad'],
+    });
+  });
+
+  it('getSimilarGames returns games sharing tags', async () => {
+    const tagRows = [{ tagId: 1 }];
+    const similar = [
+      { slug: 'other', title: 'Other', heroUrl: 'hero2', images: 'img2' },
+    ];
+    db.select = mockSelect([tagRows, similar]);
+    assert.deepStrictEqual(await getSimilarGames('game'), similar);
+  });
+});
+


### PR DESCRIPTION
## Summary
- replace Vitest with Node's built-in test runner via `tsx`
- document the updated test script in the README
- add query helper unit tests using a mocked database

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aed643e68c832baf3a44655f3dd4a5