### PR TITLE
Remove reviews from nav and show game counts

### DIFF
--- a/src/app/games/page.tsx
+++ b/src/app/games/page.tsx
@@ -22,11 +22,14 @@ export default async function Page({
     score: r.score != null ? Number(r.score) : null,
     releaseDate: r.releaseDate,
   }));
+  const totalGames = items.length;
 
   return (
     <main className="mx-auto max-w-screen-xl px-[var(--container-x)] pt-[var(--section-pt)] pb-[var(--section-pb)] 2xl:px-0">
       <header className="mb-[var(--space-8)] flex items-center gap-4">
-        <h1 className="text-3xl font-bold tracking-tight">All Games</h1>
+        <h1 className="text-3xl font-bold tracking-tight">
+          All Games ({totalGames})
+        </h1>
         <SortSelect />
       </header>
       <ul className="grid gap-[var(--block-gap)] sm:grid-cols-2 lg:grid-cols-3">

--- a/src/app/tags/[tag]/page.tsx
+++ b/src/app/tags/[tag]/page.tsx
@@ -24,12 +24,13 @@ export default async function Page({
     score: r.score != null ? Number(r.score) : null,
     releaseDate: r.releaseDate,
   }));
+  const totalGames = items.length;
 
   return (
     <main className="mx-auto max-w-screen-xl px-[var(--container-x)] pt-[var(--section-pt)] pb-[var(--section-pb)] 2xl:px-0">
       <header className="mb-[var(--space-8)] flex items-center gap-4">
         <h1 className="text-3xl font-bold tracking-tight">
-          {decodeURIComponent(params.tag)}
+          {decodeURIComponent(params.tag)} ({totalGames})
         </h1>
         <SortSelect />
       </header>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -22,7 +22,6 @@ export default function Header() {
           {/* Desktop Navigation */}
           <nav className="hidden md:flex items-center gap-8 text-sm font-medium">
             <Link href="/games" className="text-white/90 hover:text-white transition">Games</Link>
-            <Link href="/reviews" className="text-white/90 hover:text-white transition">Reviews</Link>
             <Link href="/about" className="text-white/90 hover:text-white transition">About</Link>
           </nav>
 
@@ -41,7 +40,6 @@ export default function Header() {
           <nav className="md:hidden pb-4">
             <div className="flex flex-col gap-2 rounded-lg bg-white/20 p-3 ring-1 ring-white/20 backdrop-blur">
               <Link onClick={() => setOpen(false)} href="/games" className="rounded px-3 py-2 text-white/95 hover:bg-white/10">Games</Link>
-              <Link onClick={() => setOpen(false)} href="/reviews" className="rounded px-3 py-2 text-white/95 hover:bg-white/10">Reviews</Link>
               <Link onClick={() => setOpen(false)} href="/about" className="rounded px-3 py-2 text-white/95 hover:bg-white/10">About</Link>
             </div>
           </nav>


### PR DESCRIPTION
## Summary
- Remove Reviews link from header navigation
- Display total game counts on All Games and tag pages

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b220f850ac832b8dbce91577cdce4e