### PR TITLE
feat: add release date sorting

### DIFF
--- a/src/app/games/page.tsx
+++ b/src/app/games/page.tsx
@@ -8,10 +8,14 @@ export default async function Page({
 }: {
   searchParams: { sort?: string };
 }) {
-  const order = ['score', 'publishedAt', 'title'].includes(
+  const order = ['score', 'publishedAt', 'title', 'releaseDate'].includes(
     searchParams.sort ?? ''
   )
-    ? (searchParams.sort as 'score' | 'publishedAt' | 'title')
+    ? (searchParams.sort as
+        | 'score'
+        | 'publishedAt'
+        | 'title'
+        | 'releaseDate')
     : 'publishedAt';
 
   const rows = await getAllReviews(order);

--- a/src/app/tags/[tag]/page.tsx
+++ b/src/app/tags/[tag]/page.tsx
@@ -10,10 +10,14 @@ export default async function Page({
   params: { tag: string };
   searchParams: { sort?: string };
 }) {
-  const order = ['score', 'publishedAt', 'title'].includes(
+  const order = ['score', 'publishedAt', 'title', 'releaseDate'].includes(
     searchParams.sort ?? ''
   )
-    ? (searchParams.sort as 'score' | 'publishedAt' | 'title')
+    ? (searchParams.sort as
+        | 'score'
+        | 'publishedAt'
+        | 'title'
+        | 'releaseDate')
     : 'publishedAt';
 
   const rows = await getReviewsByTag(decodeURIComponent(params.tag), order);

--- a/src/components/SortSelect.tsx
+++ b/src/components/SortSelect.tsx
@@ -6,6 +6,7 @@ const options = [
   { value: 'publishedAt', label: 'Newest' },
   { value: 'score', label: 'Score' },
   { value: 'title', label: 'Title' },
+  { value: 'releaseDate', label: 'Release Date' },
 ];
 
 export default function SortSelect() {

--- a/src/lib/queries.test.ts
+++ b/src/lib/queries.test.ts
@@ -75,6 +75,22 @@ describe('queries', () => {
     assert.deepStrictEqual(await getAllReviews(), all);
   });
 
+  it('getAllReviews allows sorting by release date', async () => {
+    const all = [
+      {
+        slug: 'game-1',
+        title: 'Game 1',
+        heroUrl: 'hero1',
+        images: 'img1',
+        score: 90,
+        publishedAt: new Date('2024-01-01'),
+        releaseDate: '2024-01-01',
+      },
+    ];
+    db.select = mockSelect([all]);
+    assert.deepStrictEqual(await getAllReviews('releaseDate'), all);
+  });
+
   it('getGameBySlug formats game data', async () => {
     const rows = [
       {

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -172,13 +172,15 @@ export async function getSimilarGames(slug: string, limit = 4) {
 }
 
 export async function getAllReviews(
-    orderBy: 'score' | 'publishedAt' | 'title' = 'publishedAt'
+    orderBy: 'score' | 'publishedAt' | 'title' | 'releaseDate' = 'publishedAt'
 ) {
     const orderColumn =
         orderBy === 'score'
             ? reviews.score
             : orderBy === 'title'
             ? games.title
+            : orderBy === 'releaseDate'
+            ? games.releaseDate
             : reviews.publishedAt;
 
     const coverImageSubquery = sql<string>`(
@@ -207,13 +209,15 @@ export async function getAllReviews(
 
 export async function getReviewsByTag(
     tag: string,
-    orderBy: 'score' | 'publishedAt' | 'title' = 'publishedAt'
+    orderBy: 'score' | 'publishedAt' | 'title' | 'releaseDate' = 'publishedAt'
 ) {
     const orderColumn =
         orderBy === 'score'
             ? reviews.score
             : orderBy === 'title'
             ? games.title
+            : orderBy === 'releaseDate'
+            ? games.releaseDate
             : reviews.publishedAt;
 
     const coverImageSubquery = sql<string>`(


### PR DESCRIPTION
## Summary
- allow games to be ordered by release date
- expose release date in sort selector
- test new release date sorting option

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b88ed4fc5c832b9a520f4c7de957bd