### PR TITLE
Add release dates to homepage cards

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -32,6 +32,7 @@ export default async function Page() {
       summary: r.summary,
       heroUrl: r.heroUrl,
       score: r.score != null ? Number(r.score) : null,
+      releaseDate: r.releaseDate,
       images: r.images ? [r.images] : null,
       image: coverOf(r),
     }));

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -28,6 +28,7 @@ export async function getRecentReviews(limit = 8) {
         heroUrl: games.heroUrl,
         score: reviews.score,
         publishedAt: reviews.publishedAt,
+        releaseDate: games.releaseDate,
         images: coverImageSubquery,
     })
         .from(reviews)


### PR DESCRIPTION
Add release dates to review cards on the homepage by fetching the `releaseDate` and passing it to the existing `ReviewCard` component for consistent display.

---
<a href="https://cursor.com/background-agent?bcId=bc-693313b0-9721-4d9a-a4ce-e68263aa2749">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-693313b0-9721-4d9a-a4ce-e68263aa2749">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

