### PR TITLE
Check cached pages

### DIFF
--- a/src/app/games/page.tsx
+++ b/src/app/games/page.tsx
@@ -3,6 +3,8 @@ import ReviewCard, { ReviewCardProps } from '@/components/ReviewCard';
 import { getAllReviews } from '@/lib/queries';
 import { coverOf } from '@/lib/ui-helpers';
 
+export const revalidate = 3600;
+
 export default async function Page({
   searchParams,
 }: {

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -2,6 +2,8 @@ import { db } from '@/lib/db';
 import { games, reviews } from '@/lib/schema';
 import { eq } from 'drizzle-orm';
 
+export const revalidate = 86400;
+
 export default async function sitemap() {
   const base = 'https://bestof.games';
   

--- a/src/app/tags/[tag]/page.tsx
+++ b/src/app/tags/[tag]/page.tsx
@@ -3,6 +3,8 @@ import ReviewCard, { ReviewCardProps } from '@/components/ReviewCard';
 import { getReviewsByTag } from '@/lib/queries';
 import { coverOf } from '@/lib/ui-helpers';
 
+export const revalidate = 3600;
+
 export default async function Page({
   params,
   searchParams,


### PR DESCRIPTION
Add ISR caching to `/games` and `/tags/[tag]` for 1 hour and to `sitemap` for 1 day to improve performance and reduce database load.

---
<a href="https://cursor.com/background-agent?bcId=bc-257252ad-a83b-4b50-a306-021210164dd5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-257252ad-a83b-4b50-a306-021210164dd5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

