### PR TITLE
Fix dynamic import ssr error

### DIFF
--- a/src/app/wishlist/page.tsx
+++ b/src/app/wishlist/page.tsx
@@ -1,6 +1,4 @@
-import dynamic from "next/dynamic";
-
-const WishlistClient = dynamic(() => import("./WishlistClient"), { ssr: false });
+import WishlistClient from "./WishlistClient";
 
 export default function WishlistPage() {
   return <WishlistClient />;


### PR DESCRIPTION
Remove `next/dynamic` with `ssr: false` from `src/app/wishlist/page.tsx` to fix a Turbopack build error.

The `WishlistClient` is already a Client Component, making the `next/dynamic` import with `ssr: false` redundant and incompatible with Next.js Server Components.

---
<a href="https://cursor.com/background-agent?bcId=bc-1c9ecdd8-13db-4a0f-a81a-9a15a5892076">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1c9ecdd8-13db-4a0f-a81a-9a15a5892076">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

